### PR TITLE
feat: Allow loading and serializing with `tensorizer`

### DIFF
--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -421,8 +421,7 @@ class ExLlamaV2Config:
 
         if no_tensors: return
 
-        self.tensor_file_map: dict = {}
-
+        self.tensor_file_map = {}
 
         st_pattern = os.path.join(self.model_dir, "*.safetensors")
         self.tensor_files = glob.glob(st_pattern)

--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -68,6 +68,7 @@ class ExLlamaV2:
     modules: list[ExLlamaV2Module]
     modules_dict: dict[str: ExLlamaV2Module]
     device_context: list[ExLlamaV2DeviceContext | None]
+    state_dict: dict[str: torch.nn.Parameter]
     cache_map: dict[int: str]
     last_kv_layer_idx: int
     head_layer_idx: int
@@ -86,6 +87,7 @@ class ExLlamaV2:
         self.modules = []
         self.modules_dict = {}
         self.device_context = []
+        self.state_dict = {}
         self.cache_map = {}
         self.loaded = False
         self.tp_context = None
@@ -127,6 +129,15 @@ class ExLlamaV2:
             norm = ExLlamaV2RMSNorm(self, cfg.arch.lm_prefix + "model.norm")
         else:
             raise ValueError("unknown norm type")
+
+        if self.config.load_with_tensorizer:
+            from tensorizer import TensorDeserializer
+            from util.tensorizer_utils import read_stream
+            with read_stream(
+                    os.path.join(self.config.model_dir, "model.tensors"),
+                    **self.config.tensorizer_args) as stream:
+                self.state_dict = TensorDeserializer(stream)
+
         self.modules += [norm]
 
         self.head_layer_idx = len(self.modules)
@@ -319,7 +330,10 @@ class ExLlamaV2:
         with torch.inference_mode():
             set_device_streams()
 
-            stats_ = self.set_device_map(gpu_split or [99999])
+            if self.config.load_with_tensorizer:
+                stats_ = self.set_device_map(gpu_split or [99999], embed_cpu = False)
+            else:
+                stats_ = self.set_device_map(gpu_split or [99999])
 
             # Load module weights
 

--- a/exllamav2/module.py
+++ b/exllamav2/module.py
@@ -25,6 +25,12 @@ class ExLlamaV2Module:
     submodules: list[ExLlamaV2Module]
     assumed_footprint: int
 
+    def __new__(cls, *args, **kwargs):
+        assert isinstance(args[0], ExLlamaV2Config)
+        if args[0].load_with_tensorizer:
+            from util.tensorizer_utils import TensorizerModuleExtension
+            return TensorizerModuleExtension(*args, **kwargs)
+
     def __init__(
         self,
         model: ExLlamaV2,
@@ -76,17 +82,6 @@ class ExLlamaV2Module:
         size = 0
 
         # key = self.key if override_key is None else override_key
-        if self.model.config.load_with_tensorizer:
-            for k in keys:
-                ck = key + "." + k
-                if measure:
-                    if ck in self.model.state_dict:
-                        ## TODO: Verify that this is a valid stand-in for
-                        ##       stfile.measure()
-                        size += int(self.model.state_dict[ck].nbytes)
-                elif ck in self.model.state_dict.keys():
-                    tensors[k] = self.model.state_dict[ck]
-            return size if measure else tensors
 
         for k in keys:
             ck = key + "." + k

--- a/exllamav2/tokenizer/tokenizer.py
+++ b/exllamav2/tokenizer/tokenizer.py
@@ -123,8 +123,24 @@ class ExLlamaV2Tokenizer:
 
         # Detect tokenizer model type and initialize
 
-        path_spm = os.path.join(self.config.model_dir, "tokenizer.model")
-        path_hf = os.path.join(self.config.model_dir, "tokenizer.json")
+        # For tensorizer, write the tokenizer files to the model directory
+        # for simplicity
+        import tempfile
+        temp_dir = tempfile.TemporaryDirectory()
+
+        ## TODO: This is hideous. Clean this up once it works
+        from util.tensorizer_utils import io_handler, read_stream
+        if self.config.load_with_tensorizer:
+            with read_stream(
+                os.path.join(self.config.model_dir, "tokenizer.json"),
+                **self.config.tensorizer_args
+            ) as stream:
+                    with open(os.path.join(temp_dir.name, "tokenizer.json"), "wb") as f:
+                        f.write(stream.read())
+            self.config.model_dir = temp_dir.name
+        with io_handler(config.load_with_tensorizer):
+            path_spm = os.path.join(self.config.model_dir, "tokenizer.model")
+            path_hf = os.path.join(self.config.model_dir, "tokenizer.json")
 
         if os.path.exists(path_hf) and not force_spm:
             self.tokenizer_model = ExLlamaV2TokenizerHF(path_hf)
@@ -135,37 +151,37 @@ class ExLlamaV2Tokenizer:
         else:
             raise FileNotFoundError("No supported tokenizer found.")
 
-        # Attempt to load added tokens from tokenizer.json
+            # Attempt to load added tokens from tokenizer.json
 
-        self.extended_piece_to_id = {}
-        self.unspecial_piece_to_id = {}
+            self.extended_piece_to_id = {}
+            self.unspecial_piece_to_id = {}
 
-        tokenizer_json_path = os.path.join(self.config.model_dir, "tokenizer.json")
-        if os.path.exists(tokenizer_json_path):
-            with open(tokenizer_json_path, encoding = "utf8") as f:
-                tokenizer_json = json.load(f)
-                if "added_tokens" in tokenizer_json:
-                    for v in tokenizer_json["added_tokens"]:
-                        if v["special"]:
-                            self.extended_piece_to_id[v["content"]] = v["id"]
-                        else:
-                            self.unspecial_piece_to_id[v["content"]] = v["id"]
+            tokenizer_json_path = os.path.join(self.config.model_dir, "tokenizer.json")
+            if os.path.exists(tokenizer_json_path):
+                with open(tokenizer_json_path, encoding = "utf8") as f:
+                    tokenizer_json = json.load(f)
+                    if "added_tokens" in tokenizer_json:
+                        for v in tokenizer_json["added_tokens"]:
+                            if v["special"]:
+                                self.extended_piece_to_id[v["content"]] = v["id"]
+                            else:
+                                self.unspecial_piece_to_id[v["content"]] = v["id"]
 
-        # Attempt to load tokenizer_config.json
+            # Attempt to load tokenizer_config.json
 
-        tokenizer_config_json_path = os.path.join(self.config.model_dir, "tokenizer_config.json")
-        if os.path.exists(tokenizer_config_json_path):
-            with open(tokenizer_config_json_path, encoding = "utf8") as f:
-                self.tokenizer_config_dict = json.load(f)
-        else:
-            self.tokenizer_config_dict = None
+            tokenizer_config_json_path = os.path.join(self.config.model_dir, "tokenizer_config.json")
+            if os.path.exists(tokenizer_config_json_path):
+                with open(tokenizer_config_json_path, encoding = "utf8") as f:
+                    self.tokenizer_config_dict = json.load(f)
+            else:
+                self.tokenizer_config_dict = None
 
-        # Add tokens from added_tokens.json if present, assume they're all special
+            # Add tokens from added_tokens.json if present, assume they're all special
 
-        added_tokens_path = os.path.join(self.config.model_dir, "added_tokens.json")
-        if os.path.exists(added_tokens_path):
-            with open(added_tokens_path, encoding = "utf8") as f:
-                self.extended_piece_to_id.update(json.load(f))
+            added_tokens_path = os.path.join(self.config.model_dir, "added_tokens.json")
+            if os.path.exists(added_tokens_path):
+                with open(added_tokens_path, encoding = "utf8") as f:
+                    self.extended_piece_to_id.update(json.load(f))
 
         # Add special tokens from tokenizer_config.json
 

--- a/exllamav2/tokenizer/tokenizer.py
+++ b/exllamav2/tokenizer/tokenizer.py
@@ -151,37 +151,37 @@ class ExLlamaV2Tokenizer:
         else:
             raise FileNotFoundError("No supported tokenizer found.")
 
-            # Attempt to load added tokens from tokenizer.json
+        # Attempt to load added tokens from tokenizer.json
 
-            self.extended_piece_to_id = {}
-            self.unspecial_piece_to_id = {}
+        self.extended_piece_to_id = {}
+        self.unspecial_piece_to_id = {}
 
-            tokenizer_json_path = os.path.join(self.config.model_dir, "tokenizer.json")
-            if os.path.exists(tokenizer_json_path):
-                with open(tokenizer_json_path, encoding = "utf8") as f:
-                    tokenizer_json = json.load(f)
-                    if "added_tokens" in tokenizer_json:
-                        for v in tokenizer_json["added_tokens"]:
-                            if v["special"]:
-                                self.extended_piece_to_id[v["content"]] = v["id"]
-                            else:
-                                self.unspecial_piece_to_id[v["content"]] = v["id"]
+        tokenizer_json_path = os.path.join(self.config.model_dir, "tokenizer.json")
+        if os.path.exists(tokenizer_json_path):
+            with open(tokenizer_json_path, encoding = "utf8") as f:
+                tokenizer_json = json.load(f)
+                if "added_tokens" in tokenizer_json:
+                    for v in tokenizer_json["added_tokens"]:
+                        if v["special"]:
+                            self.extended_piece_to_id[v["content"]] = v["id"]
+                        else:
+                            self.unspecial_piece_to_id[v["content"]] = v["id"]
 
-            # Attempt to load tokenizer_config.json
+        # Attempt to load tokenizer_config.json
 
-            tokenizer_config_json_path = os.path.join(self.config.model_dir, "tokenizer_config.json")
-            if os.path.exists(tokenizer_config_json_path):
-                with open(tokenizer_config_json_path, encoding = "utf8") as f:
-                    self.tokenizer_config_dict = json.load(f)
-            else:
-                self.tokenizer_config_dict = None
+        tokenizer_config_json_path = os.path.join(self.config.model_dir, "tokenizer_config.json")
+        if os.path.exists(tokenizer_config_json_path):
+            with open(tokenizer_config_json_path, encoding = "utf8") as f:
+                self.tokenizer_config_dict = json.load(f)
+        else:
+            self.tokenizer_config_dict = None
 
-            # Add tokens from added_tokens.json if present, assume they're all special
+        # Add tokens from added_tokens.json if present, assume they're all special
 
-            added_tokens_path = os.path.join(self.config.model_dir, "added_tokens.json")
-            if os.path.exists(added_tokens_path):
-                with open(added_tokens_path, encoding = "utf8") as f:
-                    self.extended_piece_to_id.update(json.load(f))
+        added_tokens_path = os.path.join(self.config.model_dir, "added_tokens.json")
+        if os.path.exists(added_tokens_path):
+            with open(added_tokens_path, encoding = "utf8") as f:
+                self.extended_piece_to_id.update(json.load(f))
 
         # Add special tokens from tokenizer_config.json
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ numpy~=1.26.4
 tokenizers
 rich
 pillow>=9.1.0
+tensorizer~=2.9.0

--- a/tests/test_tensorizer.py
+++ b/tests/test_tensorizer.py
@@ -1,0 +1,186 @@
+import base64
+import json
+import os
+
+from exllamav2 import (
+    ExLlamaV2,
+    ExLlamaV2Config,
+    ExLlamaV2Cache_8bit,
+    ExLlamaV2Tokenizer,
+)
+
+import pytest
+import torch
+import gc
+
+# Note: code here is very unrefined and sloppy; primarily used for
+# getting POC. Tons of things for the linter to complain about here,
+# but is that a big deal for a test script?
+
+model_dir = "../downloaded_models/model"
+serialized_dir = "../downloaded_models/tensorized"
+
+# Cleanup between tests
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def load_model(model_dir, split=None, cache_8bit=True, serialize=False,
+               use_tensorizer=False):
+
+    config = ExLlamaV2Config()
+    config.model_dir = model_dir
+    config.write_state_dict = serialize
+    config.load_with_tensorizer = use_tensorizer
+    if config.load_with_tensorizer:
+        config.serialized_dir = serialized_dir
+
+    config.prepare()
+
+    model = ExLlamaV2(config)
+    print(" -- Loading model: " + model_dir)
+
+    model.load(split)
+
+    tokenizer = ExLlamaV2Tokenizer(config)
+
+    if serialize:
+        from util.tensorizer_utils import serialize
+        serialize(model, serialized_dir)
+
+    cache = ExLlamaV2Cache_8bit(model, batch_size=4)
+    return model, tokenizer, cache
+
+
+def get_tensors(module):
+    k = module.key
+    if hasattr(module, "get_weight"):
+        w = module.get_weight()
+        if isinstance(w, tuple):
+            yield (f"{k}.weight", w[0])
+            yield (f"{k}.bias", w[1])
+        else:
+            yield (f"{k}.weight", w)
+    for submodule in module.submodules:
+        yield from get_tensors(submodule)
+
+
+def extract_tensors(model):
+    for module in model.modules:
+        yield from get_tensors(module)
+
+
+import hashlib
+
+
+def tensor_hash(t):
+    mv = t.cpu().numpy().data
+    h = hashlib.sha256()
+    h.update(str(t.dtype).encode("ascii"))
+    h.update(b"\0")
+    h.update(str(tuple(t.size())).encode("ascii"))
+    h.update(b"\0")
+    h.update(mv)
+    return h.digest()
+
+
+# The next two tests are to save tensors for comparison
+# in `test_tensorizer_loaded_is_same_model`, and are meant to be
+# ran, rather ungracefully, in separate processes,
+# for memory management reasons
+def test_get_hashed_tensors_from_normal_model():
+    model, tokenizer, cache = load_model(model_dir=model_dir, serialize=True)
+
+    marker = "normal"
+
+    state_dict = dict(extract_tensors(model))
+
+    hash_dict = {k: base64.b64encode(tensor_hash(v)) for k, v in
+                 state_dict.items()}
+
+    with open(f'{model_dir}/hash_dict_{marker}.json', "w") as file:
+        json.dump({k: v.decode("ascii") for k, v in hash_dict.items()}, file)
+
+    ## Lazy assertion here but mostly just to save the tensors
+    assert hash_dict
+
+
+def test_get_hashed_tensors_from_deserialized_model():
+    model, tokenizer, cache = load_model(model_dir=serialized_dir,
+                                         use_tensorizer=True)
+
+    marker = "tensorized"
+
+    state_dict = dict(extract_tensors(model))
+
+    hash_dict = {k: base64.b64encode(tensor_hash(v)) for k, v in
+                 state_dict.items()}
+
+    with open(f'{serialized_dir}/hash_dict_{marker}.json', "w") as file:
+        json.dump({k: v.decode("ascii") for k, v in hash_dict.items()}, file)
+
+    ## Lazy assertion here but mostly just to save the tensors
+    assert hash_dict
+
+
+def test_tensorizer_loaded_is_same_model():
+    hash_dict_a = json.load(open(f'{model_dir}/hash_dict_normal.json'))
+    hash_dict_b = json.load(open(f'{serialized_dir}/hash_dict_tensorized.json'))
+
+    assert hash_dict_a == hash_dict_b
+
+# TODO: Add test for asserting deserialized config sameness with original config
+def test_serializing_s3():
+    s3_path = os.environ["S3_URI"] if "S3_URI" in os.environ else None
+    s3_access_key_id = os.environ["S3_ACCESS_KEY_ID"] if "S3_ACCESS_KEY_ID" in os.environ else None
+    s3_secret_access_key = os.environ["S3_SECRET_ACCESS_KEY"] if "S3_SECRET_ACCESS_KEY" in os.environ else None
+    s3_endpoint = os.environ["S3_ENDPOINT_URL"] if "S3_ENDPOINT_URL" in os.environ else None
+
+    from util.tensorizer_utils import serialize
+
+    config = ExLlamaV2Config()
+    config.model_dir = model_dir
+    config.write_state_dict = True
+
+    config.prepare()
+
+    model = ExLlamaV2(config)
+    model.load()
+
+    s3_creds = {
+        "s3_access_key_id": s3_access_key_id,
+        "s3_secret_access_key": s3_secret_access_key,
+        "s3_endpoint": s3_endpoint
+    }
+
+    serialize(model,
+              s3_path,
+              s3_creds=s3_creds
+              )
+
+def test_deserialize_s3():
+    s3_path = os.environ["S3_URI"] if "S3_URI" in os.environ else None
+    s3_access_key_id = os.environ["S3_ACCESS_KEY_ID"] if "S3_ACCESS_KEY_ID" in os.environ else None
+    s3_secret_access_key = os.environ["S3_SECRET_ACCESS_KEY"] if "S3_SECRET_ACCESS_KEY" in os.environ else None
+    s3_endpoint = os.environ["S3_ENDPOINT_URL"] if "S3_ENDPOINT_URL" in os.environ else None
+
+    from util.tensorizer_utils import deserialize_with_tensorizer
+
+    model = deserialize_with_tensorizer(s3_path,
+                                         s3_access_key_id=s3_access_key_id,
+                                         s3_secret_access_key=s3_secret_access_key,
+                                         s3_endpoint=s3_endpoint
+                                         )
+
+    assert model
+
+def test_invalid_tensorizer_config():
+    config = ExLlamaV2Config()
+    config.load_with_tensorizer = True
+    config.write_state_dict = True
+    config.model_dir = "model_dir"
+    with pytest.raises(ValueError):
+        config.prepare()

--- a/util/tensorizer_utils.py
+++ b/util/tensorizer_utils.py
@@ -1,0 +1,187 @@
+import os
+import builtins
+from tensorizer import TensorSerializer, stream_io
+from functools import partial
+from typing import ContextManager
+
+from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Tokenizer, \
+    ExLlamaV2Cache_8bit
+from exllamav2.generator import ExLlamaV2BaseGenerator, ExLlamaV2Sampler
+
+read_stream, write_stream = (
+    partial(
+        stream_io.open_stream,
+        mode=mode,
+    )
+    for mode in ("rb", "wb+")
+)
+
+def validate_tensorizer_args(config: ExLlamaV2Config) -> None:
+    if config.load_with_tensorizer and config.write_state_dict:
+        raise ValueError("Cannot load with tensorizer and write state dict "
+                         "at the same time. The `write_state_dict` parameter "
+                         "parameter should only be used for serialization, "
+                         "and the `load_with_tensorizer` parameter should "
+                         "only be used for deserialization. ")
+
+
+def serialize(model, serialized_dir, s3_creds=None):
+
+    if not s3_creds:
+        s3_creds = {}
+
+    local_config_path = os.path.join(model.config.model_dir, "config.json")
+    local_tokenizer_json_path = os.path.join(model.config.model_dir, "tokenizer.json")
+    local_tokenizer_config_json_path = os.path.join(model.config.model_dir, "tokenizer_config.json")
+
+    for path in (local_config_path, local_tokenizer_json_path):
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"File not found: {path}")
+
+    if not os.path.exists(local_tokenizer_config_json_path):
+        print(f"tokenizer_config.json not found at {local_tokenizer_config_json_path}. "
+              f"Skipping..")
+
+    if not model.config.write_state_dict:
+        raise ValueError("Model was not loaded with write_state_dict=True, "
+                         "which is necessary for serialization. ")
+
+    model_uri = os.path.join(serialized_dir, "model.tensors")
+    with write_stream(model_uri, **s3_creds) as stream:
+        serializer = TensorSerializer(stream)
+        serializer.write_state_dict(model.state_dict)
+        serializer.close()
+
+    config_path = os.path.join(serialized_dir, "config.json")
+    with write_stream(config_path, **s3_creds) as stream:
+        with open(local_config_path) as f:
+            stream.write(f.read().encode("utf-8"))
+
+    tokenizer_json_path = os.path.join(serialized_dir, "tokenizer.json")
+    with write_stream(tokenizer_json_path, **s3_creds) as stream:
+        with open(local_tokenizer_json_path) as f:
+            stream.write(f.read().encode("utf-8"))
+
+    if os.path.exists(local_tokenizer_config_json_path):
+        tokenizer_config_json_path = os.path.join(serialized_dir, "tokenizer_config.json")
+        with write_stream(tokenizer_config_json_path, **s3_creds) as stream:
+            with open(local_tokenizer_config_json_path) as f:
+                stream.write(f.read().encode("utf-8"))
+
+## Deserialization example
+
+def deserialize_with_tensorizer(model_dir: str, **kwargs):
+    config = ExLlamaV2Config()
+    config.model_dir = model_dir
+
+    # Also can be enabled by specifying `TENSORIZER` in env vars
+    config.load_with_tensorizer = True
+    config.prepare()
+
+    for key, value in kwargs.items():
+        setattr(config, key, value)
+
+    model = ExLlamaV2(config)
+    model.load()
+
+    tokenizer = ExLlamaV2Tokenizer(config)
+
+    cache = ExLlamaV2Cache_8bit(model, batch_size=4)
+
+    generator = ExLlamaV2BaseGenerator(model, cache, tokenizer)
+
+    generator.warmup()
+
+    print(f" -- Generating...")
+    print()
+
+    settings = ExLlamaV2Sampler.Settings()
+    settings.temperature = 1.0
+    settings.top_k = 0
+    settings.top_p = 0.8
+    settings.token_repetition_penalty = 1.02
+    settings.disallow_tokens(tokenizer, [tokenizer.eos_token_id])
+
+
+    output = generator.generate_simple("Once upon a time,", settings, 100,
+                                       token_healing=True)
+    print(output)
+    return model
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser(description="Serialize a model")
+    parser.add_argument("--model-dir", type=str, required=True,
+                        help="The directory containing the model artifacts")
+    parser.add_argument("--serialized-dir", type=str, required=False,
+                        help="The directory to serialize the model to. "
+                             "Defaults to model_dir")
+    parser.add_argument("--deserialize", action="store_true",
+                        help="Test deserialized model outputs")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model_dir = args.model_dir
+    serialized_dir = os.environ["S3_URI"]
+    if not serialized_dir:
+        serialized_dir = model_dir
+
+    if args.deserialize:
+        deserialize_with_tensorizer(serialized_dir)
+        return
+
+    config = ExLlamaV2Config()
+    config.model_dir = model_dir
+    config.write_state_dict = True
+    if config.load_with_tensorizer:
+        config.serialized_dir = serialized_dir
+
+    config.prepare()
+
+    model = ExLlamaV2(config)
+    model.load()
+
+    serialize(model, serialized_dir)
+
+
+def io_handler(use_tensorizer: bool) -> ContextManager:
+    return _IOHandlerImpl(use_tensorizer)
+
+
+class _IOHandlerImpl:
+
+    def __init__(self, use_tensorizer: bool):
+        self.use_tensorizer = use_tensorizer
+        self._open = builtins.open
+        self._file_exists = os.path.exists
+        self._path_join = os.path.join
+
+    def modified_open(self, *args, **kwargs):
+        tensorizer_args = kwargs.get("tensorizer_args", None)
+        if self.use_tensorizer and tensorizer_args:
+            assert isinstance(tensorizer_args,
+                              dict), "tensorizer_args must be a dict"
+            return read_stream(*args, **tensorizer_args)
+        else:
+            return self._open(*args, **kwargs)
+
+    def modified_file_exists(self, *args, **kwargs):
+        if self.use_tensorizer:
+            return True
+        else:
+            return self._file_exists(*args, **kwargs)
+
+
+
+    def __enter__(self):
+        builtins.open = self.modified_open
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        builtins.open = self._open
+
+
+
+if __name__ == "__main__":
+    main()

--- a/util/tensorizer_utils.py
+++ b/util/tensorizer_utils.py
@@ -53,6 +53,12 @@ def serialize(model, serialized_dir, s3_creds=None):
         serializer.close()
 
     config_path = os.path.join(serialized_dir, "config.json")
+
+    # This is why the tensorizer directory needs to differ from
+    # the local model directory. If write_stream tries to open
+    # config_path for writing, but it's the same as local_config_path,
+    # the file writing model will clear the contents in local_config_path
+    # before reading
     with write_stream(config_path, **s3_creds) as stream:
         with open(local_config_path) as f:
             stream.write(f.read().encode("utf-8"))


### PR DESCRIPTION
This draft PR aims to unintrusively integrate `tensorizer` in to `exllamav2`'s model loading machinery, along with adding tests for correctness and avoiding regressions.

Currently in a draft PR stage. The tests have been most recently updated, but the core logic needs to be made less intrusive and less smelly.

Still to add:
- [x] Add comments to test file for better clarity 
- [ ] Make way `tensorizer` is exposed in config machinery less intrusive
- [ ] Decide whether to use `io_handler` for all Tensorizer I/O stuff or retire it altogether
- [ ] Consider rethinking the way packaging tensorizer configurable stuff is done, whether it needs a dedicated arguments class or if just packing them in their config class is appropriate
- [ ] Decide if `.state_dict` should be a public attribute 
- [ ] Allow passing TensorDeserializer args to calls to TensorDeserializer with some wrapper