### PR TITLE
feat: Try experimental commit making tensorizer less intrusive

### DIFF
--- a/exllamav2/model.py
+++ b/exllamav2/model.py
@@ -68,7 +68,6 @@ class ExLlamaV2:
     modules: list[ExLlamaV2Module]
     modules_dict: dict[str: ExLlamaV2Module]
     device_context: list[ExLlamaV2DeviceContext | None]
-    state_dict: dict[str: torch.nn.Parameter]
     cache_map: dict[int: str]
     last_kv_layer_idx: int
     head_layer_idx: int
@@ -87,7 +86,6 @@ class ExLlamaV2:
         self.modules = []
         self.modules_dict = {}
         self.device_context = []
-        self.state_dict = {}
         self.cache_map = {}
         self.loaded = False
         self.tp_context = None
@@ -129,15 +127,6 @@ class ExLlamaV2:
             norm = ExLlamaV2RMSNorm(self, cfg.arch.lm_prefix + "model.norm")
         else:
             raise ValueError("unknown norm type")
-
-        if self.config.load_with_tensorizer:
-            from tensorizer import TensorDeserializer
-            from util.tensorizer_utils import read_stream
-            with read_stream(
-                    os.path.join(self.config.model_dir, "model.tensors"),
-                    **self.config.tensorizer_args) as stream:
-                self.state_dict = TensorDeserializer(stream)
-
         self.modules += [norm]
 
         self.head_layer_idx = len(self.modules)

--- a/exllamav2/tokenizer/tokenizer.py
+++ b/exllamav2/tokenizer/tokenizer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from exllamav2.config import ExLlamaV2Config
+from exllamav2.config import ExLlamaV2Config, tensorizer_context
 import torch
 import os, json, re
 from exllamav2.tokenizer import (
@@ -76,6 +76,7 @@ class ExLlamaV2Tokenizer:
 
     tokenizer_config_dict: dict | None
 
+    @tensorizer_context
     def __init__(
         self,
         config,
@@ -123,24 +124,8 @@ class ExLlamaV2Tokenizer:
 
         # Detect tokenizer model type and initialize
 
-        # For tensorizer, write the tokenizer files to the model directory
-        # for simplicity
-        import tempfile
-        temp_dir = tempfile.TemporaryDirectory()
-
-        ## TODO: This is hideous. Clean this up once it works
-        from util.tensorizer_utils import io_handler, read_stream
-        if self.config.load_with_tensorizer:
-            with read_stream(
-                os.path.join(self.config.model_dir, "tokenizer.json"),
-                **self.config.tensorizer_args
-            ) as stream:
-                    with open(os.path.join(temp_dir.name, "tokenizer.json"), "wb") as f:
-                        f.write(stream.read())
-            self.config.model_dir = temp_dir.name
-        with io_handler(config.load_with_tensorizer):
-            path_spm = os.path.join(self.config.model_dir, "tokenizer.model")
-            path_hf = os.path.join(self.config.model_dir, "tokenizer.json")
+        path_spm = os.path.join(self.config.model_dir, "tokenizer.model")
+        path_hf = os.path.join(self.config.model_dir, "tokenizer.json")
 
         if os.path.exists(path_hf) and not force_spm:
             self.tokenizer_model = ExLlamaV2TokenizerHF(path_hf)


### PR DESCRIPTION
I feel my current feature branch was proposing fairly "ambitious" changes for exllamav2, or at least ones that would ask the maintainer(s) to add fairly significant properties to their inference engine (like a `state_dict` as a public attribute for their config class).

I tried in this commit to see if I could integrate `tensorizer` in a way that minimizes modifications _plainly in the source code_ of exllamav2's model loading machinery by applying the `tensorizer_context` decorator to functions where `tensorizer` hooks are needed.

This is unfinished and shoddy. I honestly _do not_ need to go this overboard to make my PR "less intrusive" with this proposal of changes, but felt it might be interesting to consider. Some motivations for this weren't necessarily made "better" either (for instance, I still create a private `_state_dict` attribute for their config class, but only if the decorator is called).

I figured I'd get initial feedback before going off in this direction, and scrapping it otherwise, while this change is still unfinished.


This change should (hopefully) make for a smaller line count in their core logic. The diff here is for my feature branch, but this can be made clear when comparing to this fork's `master` branch. It also likely might make the integration less readable as it plays with things like attributes for function objects. It also tries to modularize certain parts of exl2's loading logic in to functions to apply hooks in to, which goes against the unintrusiveness idealism.